### PR TITLE
Deactivate TRANSLATE rule

### DIFF
--- a/recommended.cfj
+++ b/recommended.cfj
@@ -480,7 +480,7 @@
     },
     {
       "ruleID": "TRANSLATE",
-      "isActive": true,
+      "isActive": false,
       "settingCount": 4,
       "settings": {
         "ReplaceTranslateToUpperLower": "1",


### PR DESCRIPTION
Deactivated because of: https://github.com/SAP/abap-cleaner/issues/318
In summary, in rare cases this rule can cause syntax errors.

We can reactivate it once the rule considers the variable type.